### PR TITLE
Bugfix for the rendering of tags that have a namespace but no other attributes.

### DIFF
--- a/src/Halogen/VDom/StringRenderer.purs
+++ b/src/Halogen/VDom/StringRenderer.purs
@@ -47,7 +47,7 @@ render getTagType renderAttrs renderWidget = go
       as = renderAttrs attrs
       as' = maybe as (\(Namespace ns) -> "xmlns=\"" <> escape ns <> "\"" <> if S.null as then "" else " " <> as) maybeNamespace
     in
-      "<" <> name <> (if S.null as then "" else " ") <> as' <>
+      "<" <> name <> (if S.null as' then "" else " ") <> as' <>
         if A.null children
         then if getTagType elemName == SelfClosingTag then "/>" else "></" <> name <> ">"
         else ">" <> S.joinWith "" (map go children) <> "</" <> name <> ">"


### PR DESCRIPTION
Due to a mixup with primed and non-primed variable names (`as` and
`as'`), if you have an element with a namespace but no attributes,
such as `SVG.g [] [ ... ]` it was rendering as: `<gxmlns="..."`.

This commit fixes that behaviour.